### PR TITLE
Added policies for crisp sources

### DIFF
--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<csp_whitelist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Csp:etc/csp_whitelist.xsd">
+    <policies>
+        <policy id="font-src">
+            <values>
+                <value id="crisp" type="host">*.crisp.chat</value>
+            </values>
+        </policy>
+        <policy id="script-src">
+            <values>
+                <value id="crisp" type="host">*.crisp.chat</value>
+            </values>
+        </policy>
+        <policy id="style-src">
+            <values>
+                <value id="crisp" type="host">*.crisp.chat</value>
+            </values>
+        </policy>
+        <policy id="connect-src">
+            <values>
+                <value id="crisp" type="host">*.crisp.chat</value>
+            </values>
+        </policy>
+        <policy id="img-src">
+            <values>
+                <value id="crisp" type="host">*.crisp.chat</value>
+            </values>
+        </policy>
+    </policies>
+</csp_whitelist>


### PR DESCRIPTION
Since Magento 2.4 policies have been added to prevent malicious scripts. I've added the necessary policies to whitelist crisp.